### PR TITLE
Test zipp==3.16.0 compatibility with python 3.7

### DIFF
--- a/.github/workflows/test_conda_py37.yml
+++ b/.github/workflows/test_conda_py37.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Conda install zipp
         run: |
           conda install zipp
+          conda list --show-channel-urls
 
       - name: Test import zipp
         run: |

--- a/.github/workflows/test_conda_py37.yml
+++ b/.github/workflows/test_conda_py37.yml
@@ -1,0 +1,34 @@
+name: Test installing and running zipp from conda-forge in conda py37
+on:
+  pull_request:
+
+jobs:
+  run-test:
+    name: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: "3.7"
+          channels: conda-forge
+
+      - name: Conda set up and reporting
+        run: |
+          conda config --set always_yes yes --set changeps1 no
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
+
+      - name: Conda install zipp
+        run: |
+          conda install zipp
+
+      - name: Test import zipp
+        run: |
+          python -c "import zipp; print(zipp.__version__)"


### PR DESCRIPTION
zipp 3.16.0 was just released. It removed Python 3.7 compatibility. However, the conda-forge [zipp-feedstock](https://github.com/conda-forge/zipp-feedstock) says that it can still run on Python 3.7. This PR and GitHub Action tests whether that is true.